### PR TITLE
replace readdir_r with readdir

### DIFF
--- a/sysdeps/linux-gnu/proc.c
+++ b/sysdeps/linux-gnu/proc.c
@@ -242,9 +242,10 @@ process_tasks(pid_t pid, pid_t **ret_tasks, size_t *ret_n)
 	size_t alloc = 0;
 
 	while (1) {
-		struct dirent entry;
 		struct dirent *result;
-		if (readdir_r(d, &entry, &result) != 0) {
+		errno = 0;
+		result = readdir(d);
+		if (errno != 0) {
 		fail:
 			free(tasks);
 			closedir(d);


### PR DESCRIPTION
glibc 2.24 has deprecated readdir_r

https://sourceware.org/ml/libc-alpha/2016-02/msg00093.html

@kraj: As Alioth.Debian.org ended git host service, some patches of upstream seem to be missing, so I've been submitting to the maintainer's git repo instead.

Signed-off-by: Khem Raj <raj.khem@gmail.com>