### PR TITLE
Use correct enum type

### DIFF
--- a/sysdeps/linux-gnu/aarch64/fetch.c
+++ b/sysdeps/linux-gnu/aarch64/fetch.c
@@ -173,7 +173,7 @@ static struct fetch_script
 pass_arg(struct fetch_context const *context,
 	 struct process *proc, struct arg_type_info *info)
 {
-	enum fetch_method cvt = CVT_NOP;
+	enum convert_method cvt = CVT_NOP;
 
 	size_t sz = type_sizeof(proc, info);
 	if (sz == (size_t) -1)


### PR DESCRIPTION
Clang warns about wrong enum initializtion

@kraj: As Alioth.Debian.org ended git host service, some patches of upstream seem to be missing, so I've been submitting to the maintainer's git repo instead.

Signed-off-by: Khem Raj <raj.khem@gmail.com>