### PR TITLE
ARM code has unreachable code after switch statement move initialization

### DIFF
--- a/sysdeps/linux-gnu/arm/trace.c
+++ b/sysdeps/linux-gnu/arm/trace.c
@@ -155,6 +155,8 @@ arm_get_next_pcs(struct process *proc,
 	const unsigned cond = BITS(this_instr, 28, 31);
 	const unsigned opcode = BITS(this_instr, 24, 27);
 
+	uint32_t operand1, operand2, result = 0;
+
 	if (cond == COND_NV)
 		switch (opcode) {
 			arch_addr_t addr;
@@ -170,7 +172,6 @@ arm_get_next_pcs(struct process *proc,
 		}
 	else
 		switch (opcode) {
-			uint32_t operand1, operand2, result = 0;
 		case 0x0:
 		case 0x1:			/* data processing */
 		case 0x2:


### PR DESCRIPTION
Fixed
sysdeps/linux-gnu/arm/trace.c:173:33: error: statement will never be executed [-Werror=switch-unreachable]
    uint32_t operand1, operand2, result = 0;
                                 ^~~~~~

@kraj: As Alioth.Debian.org ended git host service, some patches of upstream seem to be missing, so I've been submitting to the maintainer's git repo instead.

Signed-off-by: Khem Raj <raj.khem@gmail.com>